### PR TITLE
Fix GenAI init with useEffect

### DIFF
--- a/src/contexts/GenAIContext.tsx
+++ b/src/contexts/GenAIContext.tsx
@@ -25,7 +25,7 @@ export function GenAIProvider({ children }: { children: ReactNode }) {
   const [isGenAIInitialized, setIsGenAIInitialized] = useState<boolean>(false);
   const [apiKeyMissing, setApiKeyMissing] = useState<boolean>(false);
 
-  useMemo(() => {
+  useEffect(() => {
     // Use import.meta.env for Vite environment variables
     const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
     if (apiKey) {


### PR DESCRIPTION
## Summary
- use `useEffect` instead of `useMemo` in `GenAIContext`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684b39af76cc83278898b813494a6286