### PR TITLE
Fix build failure in PostCSS config

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
-fix/theme-and-icon-issues
-  plugins: []
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
 };
-


### PR DESCRIPTION
## Summary
- repair `postcss.config.cjs` after build failure

## Testing
- `npm run build`
- `npm run dev`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b46a5a40c832784af6173b86e7f9e