### PR TITLE
Fix PostCSS config syntax error

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-fix/theme-and-icon-issues
   plugins: []
 };
 


### PR DESCRIPTION
## Summary
- clean up stray text in `postcss.config.cjs`

## Testing
- `npm run build`
- `npx vitest run --environment jsdom` *(fails: assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b46ca58988327a48674275d98feab