### PR TITLE
Fix PostCSS config syntax

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,5 +1,7 @@
 module.exports = {
-fix/theme-and-icon-issues
-  plugins: []
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,3 +17,4 @@ export default defineConfig({
   // Only env vars prefixed with VITE_ are exposed
   envPrefix: 'VITE_',
 })
+


### PR DESCRIPTION
## Summary
- repair stray text in `postcss.config.cjs`
- restore truncation in `vite.config.ts`

## Testing
- `npm run build`
- `npx vitest run` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684b4972c6e4832793e9be04e5ca4c52