### PR TITLE
Improve bundle chunking

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,5 +16,15 @@ export default defineConfig({
   },
   // Only env vars prefixed with VITE_ are exposed
   envPrefix: 'VITE_',
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          monaco: ['monaco-editor'],
+        },
+      },
+    },
+    chunkSizeWarningLimit: 4000,
+  },
 })
 


### PR DESCRIPTION
## Summary
- load monaco editor lazily with a dynamic import
- configure Vite to place monaco in its own chunk and increase the chunk size warning limit

## Testing
- `npx vitest run` *(fails: document is not defined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c79ad6a088327a85863c75ecd49c8